### PR TITLE
Introduce CI to test whether the documentation builds correctly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Documentation Build Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r docs/requirements.txt
+
+    - name: Build the Documentation
+      run: |
+        cd docs
+        make html SPHINXOPTS="-W"


### PR DESCRIPTION
Introduce GitHub Action to test whether the documentation is built correctly before pushing it to `ReadtheDocs`. 
The CI will fail in case of warnings, to ensure that the documentation is well written. 